### PR TITLE
UTF-8 encode label

### DIFF
--- a/lib/Net/Gmail/IMAP/Label/Proxy.pm
+++ b/lib/Net/Gmail/IMAP/Label/Proxy.pm
@@ -165,7 +165,7 @@ sub put_label {
 			$octets += length(encode_utf8($x_label))+length(LINESEP); # 2 more for line separator
 			$new_fetch .= "{$octets}";
 			$new_fetch .= LINESEP;
-			$new_fetch .= $x_label;
+			$new_fetch .= encode_utf8($x_label);
 		} else {
 			$new_fetch .= "{$octets}";
 		}


### PR DESCRIPTION
mbsync was barfing out with a few messages with some labels because of a mismatch between the calculated octets and the actual payload size.

Interestingly, offlineimap never complains.